### PR TITLE
Improve federation of custom emoji

### DIFF
--- a/app/lib/emoji_formatter.rb
+++ b/app/lib/emoji_formatter.rb
@@ -3,8 +3,6 @@
 class EmojiFormatter
   include RoutingHelper
 
-  DISALLOWED_BOUNDING_REGEX = /[[:alnum:]:]/
-
   attr_reader :html, :custom_emojis, :options
 
   # @param [ActiveSupport::SafeBuffer] html
@@ -39,15 +37,14 @@ class EmojiFormatter
         if inside_shortname && text[i] == ':'
           inside_shortname = false
           shortcode = text[shortname_start_index + 1..i - 1]
-          char_after = text[i + 1]
 
-          next unless (char_after.nil? || !DISALLOWED_BOUNDING_REGEX.match?(char_after)) && (emoji = emoji_map[shortcode])
+          next unless (emoji = emoji_map[shortcode])
 
           result << Nokogiri::XML::Text.new(text[last_index..shortname_start_index - 1], tree.document) if shortname_start_index.positive?
           result << Nokogiri::HTML.fragment(tag_for_emoji(shortcode, emoji))
 
           last_index = i + 1
-        elsif text[i] == ':' && (i.zero? || !DISALLOWED_BOUNDING_REGEX.match?(text[i - 1]))
+        elsif text[i] == ':'
           inside_shortname = true
           shortname_start_index = i
         end

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -29,9 +29,7 @@ class CustomEmoji < ApplicationRecord
 
   SHORTCODE_RE_FRAGMENT = '[a-zA-Z0-9_]{2,}'
 
-  SCAN_RE = /(?<=[^[:alnum:]:]|\n|^)
-    :(#{SHORTCODE_RE_FRAGMENT}):
-    (?=[^[:alnum:]:]|$)/x
+  SCAN_RE = /:(#{SHORTCODE_RE_FRAGMENT}):/x
   SHORTCODE_ONLY_RE = /\A#{SHORTCODE_RE_FRAGMENT}\z/
 
   IMAGE_MIME_TYPES = %w(image/png image/gif image/webp).freeze

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -27,7 +27,7 @@ class CustomEmoji < ApplicationRecord
   LOCAL_LIMIT = (ENV['MAX_EMOJI_SIZE'] || 256.kilobytes).to_i
   LIMIT       = [LOCAL_LIMIT, (ENV['MAX_REMOTE_EMOJI_SIZE'] || 256.kilobytes).to_i].max
 
-  SHORTCODE_RE_FRAGMENT = '[a-zA-Z0-9_]{2,}'
+  SHORTCODE_RE_FRAGMENT = '[a-zA-Z0-9_-]{2,}'
 
   SCAN_RE = /:(#{SHORTCODE_RE_FRAGMENT}):/x
   SHORTCODE_ONLY_RE = /\A#{SHORTCODE_RE_FRAGMENT}\z/

--- a/spec/lib/emoji_formatter_spec.rb
+++ b/spec/lib/emoji_formatter_spec.rb
@@ -38,14 +38,6 @@ RSpec.describe EmojiFormatter do
       end
     end
 
-    context 'when given text with concatenated emoji shortcodes' do
-      let(:text) { preformat_text(':coolcat::coolcat:') }
-
-      it 'does not touch the shortcodes' do
-        expect(subject).to match(/:coolcat::coolcat:/)
-      end
-    end
-
     context 'when given text with an emoji shortcode at the end' do
       let(:text) { preformat_text('Beep boop :coolcat:') }
 


### PR DESCRIPTION
Custom emoji on other fediverse platforms can contain dashes, but Mastodon doesn't support this. Another issue is that custom emoji cannot have certain characters before/after them, including colons, making custom emoji side-by-side not display on Mastodon.
This PR fixes both of these problems by allowing dashes in emoji shortcodes and not restricting which characters emoji can come before or after. On my instance I've been trialing these changes and they work just fine :)