### PR TITLE
rewrite withIdentity to leave all other props alone

### DIFF
--- a/app/javascript/flavours/glitch/identity_context.tsx
+++ b/app/javascript/flavours/glitch/identity_context.tsx
@@ -34,37 +34,29 @@ export const IdentityContext = createContext<IdentityContextType>({
 
 export const useIdentity = () => useContext(IdentityContext);
 
-export interface IdentityProps {
-  ref?: unknown;
-  wrappedComponentRef?: unknown;
+interface IdentityInjectedProps {
+  identity: IdentityContextType;
 }
 
-/* Injects an `identity` props into the wrapped component to be able to use the new context in class components */
-export function withIdentity<
-  ComponentType extends React.ComponentType<IdentityProps>,
->(Component: ComponentType) {
-  const displayName = `withIdentity(${Component.displayName ?? Component.name})`;
-  const C = (props: React.ComponentProps<ComponentType>) => {
-    const { wrappedComponentRef, ...remainingProps } = props;
+type WithoutIdentity<Props> = Omit<Props, keyof IdentityInjectedProps>;
 
-    return (
-      <IdentityContext.Consumer>
-        {(context) => {
-          return (
-            // @ts-expect-error - Dynamic covariant generic components are tough to type.
-            <Component
-              {...remainingProps}
-              identity={context}
-              ref={wrappedComponentRef}
-            />
-          );
-        }}
-      </IdentityContext.Consumer>
-    );
-  };
+/* Injects an `identity` prop into the wrapped component to be able to use the new context in class components */
+export function withIdentity<Props extends IdentityInjectedProps>(
+  Component: React.ComponentType<Props>,
+) {
+  const displayName = `withIdentity(${Component.displayName ?? Component.name})`;
+  const C = (props: WithoutIdentity<Props>) => (
+    <IdentityContext.Consumer>
+      {(context) => {
+        const componentProps = { ...props, identity: context } as Props;
+
+        return <Component {...componentProps} />;
+      }}
+    </IdentityContext.Consumer>
+  );
 
   C.displayName = displayName;
   C.WrappedComponent = Component;
 
-  return hoistStatics(C, Component);
+  return hoistStatics(C, Component) as React.ComponentType<WithoutIdentity<Props>>;
 }


### PR DESCRIPTION
this fixes the errors when running `yarn typecheck`
passes `yarn test` but i haven't actually run the whole mastodon server to verify functionality still works

for https://github.com/glitch-soc/mastodon/pull/2462

before
```
$ yarn test
app/javascript/flavours/glitch/components/status_quoted.tsx:339:8 - error TS2322: Type '{ children: false | Element | undefined; isQuotedPost: true; id: string | null | undefined; contextType: string | undefined; avatarSize: number; headerRenderFn: StatusHeaderRenderFn; }' is not assignable to type 'IntrinsicAttributes & { wrappedComponentRef: unknown; ref: unknown; contextType: any; context?: Context<ReactReduxContextValue<any, UnknownAction> | null> | undefined; store?: Store<...> | undefined; }'.
  Property 'children' does not exist on type 'IntrinsicAttributes & { wrappedComponentRef: unknown; ref: unknown; contextType: any; context?: Context<ReactReduxContextValue<any, UnknownAction> | null> | undefined; store?: Store<...> | undefined; }'.

339       <StatusContainer
           ~~~~~~~~~~~~~~~


Found 1 error in app/javascript/flavours/glitch/components/status_quoted.tsx:339
```

after
```
$ yarn test
 Test Files  36 passed (36)
      Tests  7969 passed (7969)
   Start at  19:31:09
   Duration  11.00s (transform 42.28s, setup 9.52s, import 54.73s, tests 2.60s, environment 105.57s)
```