### PR TITLE
Add test coverage for BackupService with non-Document attachments

### DIFF
--- a/spec/services/backup_service_spec.rb
+++ b/spec/services/backup_service_spec.rb
@@ -44,6 +44,22 @@ RSpec.describe BackupService do
     end
   end
 
+  context 'when a status has a link preview card attached' do
+    let(:preview_card) { Fabricate(:preview_card) }
+
+    before { PreviewCardsStatus.create!(status: status, preview_card: preview_card) }
+
+    it 'rewrites media paths but leaves link attachments alone' do
+      service_call
+
+      expect(export_json(:outbox).dig('orderedItems', 0, 'object', 'attachment'))
+        .to contain_exactly(
+          include('type' => 'Document', 'url' => start_with('media_attachments/')),
+          include('type' => 'Link', 'href' => preview_card.url)
+        )
+    end
+  end
+
   it 'marks the backup as processed and exports files' do
     expect { service_call }.to process_backup
 


### PR DESCRIPTION
Adds the test coverage asked about in PR 39977.

I ran into this failing on my own custom features as well, so I thought a test would be worth having.

The new example attaches a preview card to a status that already has a media attachment, so a single outbox item carries both a `Document` and a `Link` attachment. It asserts that the `Document` URL is still rewritten relative to `/system/` while the `Link` attachment is left untouched. covering both sides of the new type guard.

Verified against the branch: the example passes with the fix applied, and fails with `NoMethodError` on `nil` when the guard is reverted.

Feel free to just take the test into your branch directly instead of merging this PR, if that's easier for you.